### PR TITLE
feat(dashboard): add Prometheus/OTel metrics dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,12 @@ NEXT_PUBLIC_ENVIRONMENT=development
 # Agent telemetry WebSocket (optional — omit to use built-in mock stream in the dashboard)
 # NEXT_PUBLIC_TELEMETRY_WS_URL=ws://127.0.0.1:3456
 # TELEMETRY_WS_PORT=3456
+
+# Metrics dashboard (optional — omit to use built-in mock metrics)
+# Prometheus HTTP API base URL (server-side only; do NOT prefix with NEXT_PUBLIC)
+# Example: http://localhost:9090
+# METRICS_PROMETHEUS_BASE_URL=
+#
+# If using OpenTelemetry Collector, you can point this at its Prometheus exporter
+# Example: http://localhost:9464
+# METRICS_OTEL_PROMETHEUS_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The platform combines a powerful **agent creation wizard** (describe behavior �
 - 🌌 **Galaxy Marketplace**: Browse and discover agents visualized as stars and planets
 - 💬 **Agent Chat Interface**: Interact with your AI agents in real-time
 - 📊 **Agent Portfolio**: Track your owned agents and view detailed performance statistics
+- 📈 **System & Business Dashboard**: Prometheus/OpenTelemetry-compatible metrics with filtering and CSV export (PII-safe)
 - 🎓 **Educational Mode**: Learn best practices and tutorials for building smarter agents
 - ✨ **Cosmic UI Theme**: Dark space aesthetic with glowing nebulae and animated constellations
 
@@ -99,6 +100,7 @@ stellAIverse-frontend/
 ## Helpful Links
 
 - **[Documentation](./docs)** - Detailed guides and API documentation
+- **[Metrics dashboard](./docs/metrics-dashboard.md)** - Prometheus/OpenTelemetry integration and PII policy
 - **[Contributing Guidelines](./CONTRIBUTING.md)** - How to contribute to the project
 - **[Issues](https://github.com/StellAIverse/stellAIverse-frontend/issues)** - Report bugs or request features
 - **[Discussions](https://github.com/StellAIverse/stellAIverse-frontend/discussions)** - Community discussions

--- a/app/api/metrics/panel/route.ts
+++ b/app/api/metrics/panel/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPanel } from '@/lib/metrics/panels';
+import { buildMockPanelResponse } from '@/lib/metrics/mock';
+import { getMetricsSource, queryRangePanel } from '@/lib/metrics/prometheus';
+
+function clampInt(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function parseRangeSeconds(range: string): number {
+  switch (range) {
+    case '15m':
+      return 15 * 60;
+    case '1h':
+      return 60 * 60;
+    case '6h':
+      return 6 * 60 * 60;
+    case '24h':
+      return 24 * 60 * 60;
+    case '7d':
+      return 7 * 24 * 60 * 60;
+    default:
+      return 60 * 60;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const panelId = String(searchParams.get('panelId') || '');
+    const panel = getPanel(panelId);
+    if (!panel) {
+      return NextResponse.json({ message: 'Unknown panelId' }, { status: 400 });
+    }
+
+    const range = String(searchParams.get('range') || '1h');
+    const stepRaw = Number(searchParams.get('step') || 30);
+    const step = clampInt(stepRaw, 5, 300);
+
+    const now = Math.floor(Date.now() / 1000);
+    const end = now;
+    const start = now - parseRangeSeconds(range);
+
+    const source = getMetricsSource();
+    if (source === 'mock') {
+      return NextResponse.json(buildMockPanelResponse({ panel, start, end, step }));
+    }
+
+    const result = await queryRangePanel({ panel, start, end, step, signal: request.signal });
+    return NextResponse.json({
+      panelId: panel.id,
+      ...result,
+    });
+  } catch (error: any) {
+    return NextResponse.json(
+      {
+        message: 'Failed to fetch metrics panel',
+        error: error?.message || 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/api/metrics/panels/route.ts
+++ b/app/api/metrics/panels/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { METRICS_PANELS } from '@/lib/metrics/panels';
+import { getMetricsSource } from '@/lib/metrics/prometheus';
+
+export async function GET() {
+  return NextResponse.json({
+    source: getMetricsSource(),
+    panels: METRICS_PANELS,
+  });
+}
+

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Button from '@/components/Button';
+import MetricLineChart from '@/components/metrics/MetricLineChart';
+import MetricSeriesTable from '@/components/metrics/MetricSeriesTable';
+import type { MetricsPanelResponse, MetricsPanelsResponse, MetricsRange } from '@/lib/metrics/types';
+import { panelToCsv } from '@/lib/metrics/csv';
+
+const RANGES: MetricsRange[] = ['15m', '1h', '6h', '24h', '7d'];
+
+function downloadText(filename: string, text: string, type = 'text/plain') {
+  const blob = new Blob([text], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function MetricsDashboardPage() {
+  const [group, setGroup] = useState<'system' | 'business'>('system');
+  const [range, setRange] = useState<MetricsRange>('1h');
+  const [step, setStep] = useState(30);
+  const [seriesFilter, setSeriesFilter] = useState('');
+
+  const panelsQuery = useQuery<MetricsPanelsResponse>({
+    queryKey: ['metrics-panels'],
+    queryFn: async () => {
+      const res = await fetch('/api/metrics/panels');
+      if (!res.ok) throw new Error('Failed to load panels');
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+
+  const panels = panelsQuery.data?.panels || [];
+  const filteredPanels = useMemo(
+    () => panels.filter((p) => p.group === group),
+    [panels, group]
+  );
+
+  const [panelId, setPanelId] = useState<string>('');
+  const effectivePanelId = panelId || filteredPanels[0]?.id || '';
+
+  const panelQuery = useQuery<MetricsPanelResponse>({
+    queryKey: ['metrics-panel', effectivePanelId, range, step],
+    enabled: Boolean(effectivePanelId),
+    queryFn: async () => {
+      const u = new URL('/api/metrics/panel', window.location.origin);
+      u.searchParams.set('panelId', effectivePanelId);
+      u.searchParams.set('range', range);
+      u.searchParams.set('step', String(step));
+      const res = await fetch(u.pathname + u.search);
+      if (!res.ok) throw new Error('Failed to load panel');
+      return res.json();
+    },
+    staleTime: 15_000,
+  });
+
+  const series = useMemo(() => {
+    const s = panelQuery.data?.series || [];
+    const f = seriesFilter.trim().toLowerCase();
+    if (!f) return s;
+    return s.filter((x) => x.seriesName.toLowerCase().includes(f));
+  }, [panelQuery.data, seriesFilter]);
+
+  const source = panelsQuery.data?.source || 'mock';
+  const selectedPanel = panels.find((p) => p.id === effectivePanelId) || null;
+
+  const handleExport = () => {
+    if (!panelQuery.data) return;
+    const csv = panelToCsv({ ...panelQuery.data, series });
+    downloadText(`metrics-${effectivePanelId}-${range}.csv`, csv, 'text/csv');
+  };
+
+  return (
+    <main className="pt-20 pb-20 px-4">
+      <div className="max-w-6xl mx-auto space-y-8">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-5xl font-bold glow-text">System & Business Dashboard</h1>
+          <p className="text-gray-300 text-lg">
+            Prometheus / OpenTelemetry-compatible metrics with filtering + export. PII is blocked at the API layer.
+          </p>
+          <p className="text-gray-500 text-sm">
+            Source: <span className="text-gray-300 font-semibold">{source}</span>
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-3 items-center">
+          <Button variant={group === 'system' ? 'primary' : 'outline'} onClick={() => setGroup('system')}>
+            System
+          </Button>
+          <Button variant={group === 'business' ? 'primary' : 'outline'} onClick={() => setGroup('business')}>
+            Business
+          </Button>
+
+          <div className="h-6 w-px bg-cosmic-purple/30 mx-1" />
+
+          <label className="text-sm text-gray-300">
+            Panel
+            <select
+              className="ml-2 bg-cosmic-dark/60 border border-cosmic-purple/30 rounded px-3 py-2"
+              value={effectivePanelId}
+              onChange={(e) => setPanelId(e.target.value)}
+            >
+              {filteredPanels.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.title}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="text-sm text-gray-300">
+            Range
+            <select
+              className="ml-2 bg-cosmic-dark/60 border border-cosmic-purple/30 rounded px-3 py-2"
+              value={range}
+              onChange={(e) => setRange(e.target.value as MetricsRange)}
+            >
+              {RANGES.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="text-sm text-gray-300">
+            Step
+            <input
+              className="ml-2 w-24 bg-cosmic-dark/60 border border-cosmic-purple/30 rounded px-3 py-2"
+              type="number"
+              min={5}
+              max={300}
+              value={step}
+              onChange={(e) => setStep(Number(e.target.value || 30))}
+            />
+          </label>
+
+          <Button variant="secondary" onClick={handleExport} disabled={!panelQuery.data || series.length === 0}>
+            Export CSV
+          </Button>
+        </div>
+
+        {selectedPanel ? (
+          <div className="p-6 rounded-lg border border-cosmic-purple/30 nebula-bg">
+            <div className="flex flex-col gap-1 mb-4">
+              <h2 className="text-2xl font-bold glow-text">{selectedPanel.title}</h2>
+              {selectedPanel.description ? <p className="text-gray-300">{selectedPanel.description}</p> : null}
+            </div>
+
+            <div className="flex flex-wrap gap-3 items-center mb-4">
+              <label className="text-sm text-gray-300">
+                Filter series
+                <input
+                  className="ml-2 w-72 max-w-full bg-cosmic-dark/60 border border-cosmic-purple/30 rounded px-3 py-2"
+                  placeholder="e.g. job=api"
+                  value={seriesFilter}
+                  onChange={(e) => setSeriesFilter(e.target.value)}
+                />
+              </label>
+              <div className="text-sm text-gray-400">
+                Showing <span className="text-gray-200 font-semibold">{series.length}</span> series
+              </div>
+            </div>
+
+            {panelsQuery.isLoading ? <p className="text-gray-400">Loading panels…</p> : null}
+            {panelsQuery.isError ? <p className="text-red-300">Failed to load panels.</p> : null}
+
+            {panelQuery.isLoading ? <p className="text-gray-400">Loading metrics…</p> : null}
+            {panelQuery.isError ? <p className="text-red-300">Failed to load metrics.</p> : null}
+
+            {panelQuery.data ? (
+              <div className="space-y-6">
+                <MetricLineChart series={series} />
+                <MetricSeriesTable series={series} />
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <div className="text-gray-400">No panels available.</div>
+        )}
+      </div>
+    </main>
+  );
+}
+

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -15,6 +15,7 @@ export const Navigation: React.FC = () => {
   const navLinks = [
     { href: "/marketplace", label: "Marketplace" },
     { href: "/create", label: "Create Agent" },
+    { href: "/dashboard", label: "Dashboard" },
     { href: "/analytics", label: "Analytics" },
     { href: "/telemetry", label: "Telemetry" },
     { href: "/security", label: "Security" },

--- a/components/metrics/MetricLineChart.tsx
+++ b/components/metrics/MetricLineChart.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Legend,
+} from 'recharts';
+import type { MetricsSeries } from '@/lib/metrics/types';
+
+function formatTs(tsSeconds: number) {
+  const d = new Date(tsSeconds * 1000);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function colorForIndex(i: number) {
+  const palette = ['#8b5cf6', '#06b6d4', '#22c55e', '#f59e0b', '#ef4444', '#3b82f6'];
+  return palette[i % palette.length];
+}
+
+type ChartPoint = { ts: number; label: string } & Record<string, number | null>;
+
+function buildChartData(series: MetricsSeries[]): { data: ChartPoint[]; keys: string[] } {
+  const keys = series.map((s) => s.seriesName);
+  const byTs = new Map<number, ChartPoint>();
+  for (const s of series) {
+    for (const p of s.points) {
+      const existing = byTs.get(p.ts) || { ts: p.ts, label: formatTs(p.ts) };
+      (existing as Record<string, number | null>)[s.seriesName] = p.value;
+      byTs.set(p.ts, existing);
+    }
+  }
+  const data = Array.from(byTs.values()).sort((a, b) => a.ts - b.ts);
+  return { data, keys };
+}
+
+export default function MetricLineChart({
+  series,
+  height = 280,
+}: {
+  series: MetricsSeries[];
+  height?: number;
+}) {
+  const { data, keys } = buildChartData(series);
+
+  if (series.length === 0) {
+    return <div className="text-gray-400">No data.</div>;
+  }
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <LineChart data={data} margin={{ left: 6, right: 6, top: 10, bottom: 0 }}>
+          <CartesianGrid stroke="rgba(139,92,246,0.15)" strokeDasharray="4 4" />
+          <XAxis dataKey="label" tick={{ fill: '#cbd5e1', fontSize: 12 }} />
+          <YAxis tick={{ fill: '#cbd5e1', fontSize: 12 }} />
+          <Tooltip
+            contentStyle={{
+              background: 'rgba(2,6,23,0.9)',
+              border: '1px solid rgba(139,92,246,0.35)',
+              color: '#fff',
+            }}
+          />
+          {keys.length <= 6 ? <Legend /> : null}
+          {keys.map((k, idx) => (
+            <Line
+              key={k}
+              type="monotone"
+              dataKey={k}
+              dot={false}
+              strokeWidth={2}
+              stroke={colorForIndex(idx)}
+              isAnimationActive={false}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+

--- a/components/metrics/MetricSeriesTable.tsx
+++ b/components/metrics/MetricSeriesTable.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { MetricsSeries } from '@/lib/metrics/types';
+
+function lastValue(series: MetricsSeries): number | null {
+  const p = series.points[series.points.length - 1];
+  return p ? p.value : null;
+}
+
+export default function MetricSeriesTable({ series }: { series: MetricsSeries[] }) {
+  if (series.length === 0) return null;
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-cosmic-purple/30">
+      <table className="min-w-full text-sm">
+        <thead className="bg-cosmic-dark/60">
+          <tr>
+            <th className="text-left px-4 py-3 text-gray-200 font-semibold">Series</th>
+            <th className="text-right px-4 py-3 text-gray-200 font-semibold">Latest</th>
+          </tr>
+        </thead>
+        <tbody>
+          {series.slice(0, 20).map((s) => (
+            <tr key={s.seriesName} className="border-t border-cosmic-purple/20">
+              <td className="px-4 py-3 text-gray-200">{s.seriesName}</td>
+              <td className="px-4 py-3 text-right text-cosmic-cyan font-semibold">
+                {lastValue(s) === null ? '—' : lastValue(s)!.toLocaleString()}
+              </td>
+            </tr>
+          ))}
+          {series.length > 20 ? (
+            <tr className="border-t border-cosmic-purple/20">
+              <td className="px-4 py-3 text-gray-400" colSpan={2}>
+                Showing first 20 series.
+              </td>
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/docs/metrics-dashboard.md
+++ b/docs/metrics-dashboard.md
@@ -1,0 +1,61 @@
+# Metrics dashboard (system + business)
+
+Dashboard for viewing **system** and **business** metrics with **Prometheus / OpenTelemetry** compatibility and **PII-safe** display.
+
+## Route
+
+- `/dashboard`
+
+## Features
+
+- **Charts + tables**: time-series line charts and a “latest value” table per panel.
+- **Custom business metric views**: add predefined panels in `lib/metrics/panels.ts`.
+- **Integration**:
+  - Prometheus HTTP API (`/api/v1/query_range`)
+  - OpenTelemetry Collector via Prometheus exporter (same HTTP API shape)
+- **Filtering**: client-side filter by series name (derived from **sanitized** labels).
+- **Export**: CSV export of the currently visible series.
+
+## Configuration
+
+Set one of these server-side environment variables (do **not** use `NEXT_PUBLIC_`):
+
+```env
+METRICS_PROMETHEUS_BASE_URL=http://localhost:9090
+# or
+METRICS_OTEL_PROMETHEUS_BASE_URL=http://localhost:9464
+```
+
+If neither is set, the dashboard uses **mock metrics** so the UI works out-of-the-box.
+
+## No PII policy
+
+This dashboard is **defense-in-depth**:
+
+- API layer sanitizes Prometheus label sets in `lib/metrics/sanitize.ts`:
+  - Drops sensitive label keys (e.g. `email`, `user_id`, `instance`, `ip`, `wallet`, etc.)
+  - Scrubs label values that look like emails, IPs, Stellar addresses, or long secrets.
+- UI only displays the derived `seriesName` (built from sanitized labels).
+
+**Important**: Frontend sanitization is not a substitute for server-side governance. Ensure your metrics pipeline never emits PII.
+
+## Adding a new metric panel
+
+Edit `lib/metrics/panels.ts` and add a new entry:
+
+- `id`: stable identifier
+- `group`: `system` or `business`
+- `title` / `description`
+- `promqlRange`: a safe PromQL query
+
+Panels are predefined to avoid arbitrary PromQL execution from browsers.
+
+## Acceptance mapping
+
+| Criterion | Implementation |
+|----------|----------------|
+| All major metrics are visualized | System + business panel groups in `/dashboard` |
+| No PII in any metric | Label sanitizer + UI only renders sanitized series names |
+| Export and filtering work | Series name filter + CSV export |
+| Documentation complete | This document |
+

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -7,6 +7,10 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
+  testMatch: [
+    '<rootDir>/**/__tests__/**/*.(test|spec).[tj]s?(x)',
+    '<rootDir>/**/tests/**/*.(test|spec).[tj]s?(x)',
+  ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },

--- a/lib/metrics/csv.ts
+++ b/lib/metrics/csv.ts
@@ -1,0 +1,21 @@
+import type { MetricsPanelResponse } from './types';
+
+function csvEscape(value: string | number): string {
+  const stringValue = String(value);
+  if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+    return `"${stringValue.replaceAll('"', '""')}"`;
+  }
+  return stringValue;
+}
+
+export function panelToCsv(panel: MetricsPanelResponse): string {
+  const header = ['series', 'ts', 'value'];
+  const rows: Array<[string, number, number]> = [];
+  for (const s of panel.series) {
+    for (const p of s.points) {
+      rows.push([s.seriesName, p.ts, p.value]);
+    }
+  }
+  return [header, ...rows].map((r) => r.map((v) => csvEscape(v)).join(',')).join('\n');
+}
+

--- a/lib/metrics/mock.ts
+++ b/lib/metrics/mock.ts
@@ -1,0 +1,44 @@
+import type { MetricsPanelDefinition, MetricsPanelResponse, MetricsSeries } from './types';
+import { sanitizeLabels, labelsToSeriesName } from './sanitize';
+
+function genSineSeries(panel: MetricsPanelDefinition, start: number, end: number, step: number): MetricsSeries[] {
+  const labels = sanitizeLabels({ job: 'mock', env: 'dev' });
+  const points = [];
+  const span = Math.max(1, end - start);
+  const base = panel.group === 'business' ? 50 : 20;
+  for (let t = start; t <= end; t += step) {
+    const x = (t - start) / span;
+    const noise = Math.sin(x * Math.PI * 6) * 0.15 + Math.sin(x * Math.PI * 2) * 0.1;
+    const trend = panel.id.includes('error') ? 0.02 : 0.08;
+    const raw = base * (1 + noise) + base * trend * x;
+    const value =
+      panel.unit === 'percent' ? Math.max(0, Math.min(100, raw)) : Math.max(0, raw);
+    points.push({ ts: t, value: Number(value.toFixed(4)) });
+  }
+  return [
+    {
+      seriesName: labelsToSeriesName(labels),
+      labels,
+      points,
+    },
+  ];
+}
+
+export function buildMockPanelResponse(args: {
+  panel: MetricsPanelDefinition;
+  start: number;
+  end: number;
+  step: number;
+}): MetricsPanelResponse {
+  const { panel, start, end, step } = args;
+  return {
+    panelId: panel.id,
+    source: 'mock',
+    start,
+    end,
+    step,
+    series: genSineSeries(panel, start, end, step),
+    generatedAt: new Date().toISOString(),
+  };
+}
+

--- a/lib/metrics/panels.ts
+++ b/lib/metrics/panels.ts
@@ -1,0 +1,77 @@
+import type { MetricsPanelDefinition } from './types';
+
+// Panels are intentionally predefined to avoid arbitrary PromQL execution from the browser.
+// Add panels here as you introduce new business/system KPIs.
+export const METRICS_PANELS: MetricsPanelDefinition[] = [
+  {
+    id: 'sys_http_request_rate',
+    group: 'system',
+    title: 'HTTP request rate',
+    description: 'Requests per second (all routes).',
+    unit: 'rate_per_s',
+    promqlRange: 'sum(rate(http_requests_total[5m]))',
+  },
+  {
+    id: 'sys_http_error_rate',
+    group: 'system',
+    title: 'HTTP error rate',
+    description: '5xx requests per second.',
+    unit: 'rate_per_s',
+    promqlRange: 'sum(rate(http_requests_total{status=~"5.."}[5m]))',
+  },
+  {
+    id: 'sys_http_p95_latency_ms',
+    group: 'system',
+    title: 'HTTP p95 latency',
+    description: '95th percentile latency (ms).',
+    unit: 'ms',
+    promqlRange:
+      'histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) * 1000',
+  },
+  {
+    id: 'sys_process_cpu_percent',
+    group: 'system',
+    title: 'Process CPU',
+    description: 'CPU usage percent (process-level).',
+    unit: 'percent',
+    promqlRange: 'avg(rate(process_cpu_seconds_total[5m])) * 100',
+  },
+  {
+    id: 'sys_process_memory_bytes',
+    group: 'system',
+    title: 'Process memory',
+    description: 'Resident memory bytes.',
+    unit: 'bytes',
+    promqlRange: 'avg(process_resident_memory_bytes)',
+  },
+  {
+    id: 'biz_agent_invocations_rate',
+    group: 'business',
+    title: 'Agent invocations',
+    description: 'Invocation rate per second across all agents.',
+    unit: 'rate_per_s',
+    promqlRange: 'sum(rate(agent_invocations_total[5m]))',
+  },
+  {
+    id: 'biz_agent_success_rate_percent',
+    group: 'business',
+    title: 'Agent success rate',
+    description: 'Success rate percent.',
+    unit: 'percent',
+    promqlRange:
+      '(sum(rate(agent_invocations_total{status="success"}[5m])) / clamp_min(sum(rate(agent_invocations_total[5m])), 1e-9)) * 100',
+  },
+  {
+    id: 'biz_revenue_xlm_rate',
+    group: 'business',
+    title: 'Revenue rate',
+    description: 'Revenue per second (XLM).',
+    unit: 'xlm',
+    promqlRange: 'sum(rate(agent_revenue_xlm_total[5m]))',
+  },
+];
+
+export function getPanel(panelId: string): MetricsPanelDefinition | null {
+  return METRICS_PANELS.find((p) => p.id === panelId) || null;
+}
+

--- a/lib/metrics/prometheus.ts
+++ b/lib/metrics/prometheus.ts
@@ -1,0 +1,98 @@
+import type { MetricsPanelDefinition, MetricsPanelResponse, MetricsSeries } from './types';
+import { labelsToSeriesName, sanitizeLabels } from './sanitize';
+
+type PromMatrixValue = [number | string, string];
+
+interface PromQueryRangeResponse {
+  status: 'success' | 'error';
+  errorType?: string;
+  error?: string;
+  data?: {
+    resultType: 'matrix';
+    result: Array<{
+      metric: Record<string, string>;
+      values: PromMatrixValue[];
+    }>;
+  };
+}
+
+function parseFloatSafe(v: string): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function toUnixSeconds(raw: string | number): number {
+  if (typeof raw === 'number') return raw;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function getBaseUrl(): { url: string | null; source: 'prometheus' | 'otel_prometheus' | 'mock' } {
+  const otel = process.env.METRICS_OTEL_PROMETHEUS_BASE_URL?.trim();
+  if (otel) return { url: otel, source: 'otel_prometheus' };
+  const prom = process.env.METRICS_PROMETHEUS_BASE_URL?.trim();
+  if (prom) return { url: prom, source: 'prometheus' };
+  return { url: null, source: 'mock' };
+}
+
+export function getMetricsSource() {
+  return getBaseUrl().source;
+}
+
+export async function queryRangePanel(args: {
+  panel: MetricsPanelDefinition;
+  start: number;
+  end: number;
+  step: number;
+  signal?: AbortSignal;
+}): Promise<Omit<MetricsPanelResponse, 'panelId'>> {
+  const { panel, start, end, step, signal } = args;
+  const { url, source } = getBaseUrl();
+  if (!url) {
+    return {
+      source,
+      start,
+      end,
+      step,
+      series: [],
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  const u = new URL('/api/v1/query_range', url);
+  u.searchParams.set('query', panel.promqlRange);
+  u.searchParams.set('start', String(start));
+  u.searchParams.set('end', String(end));
+  u.searchParams.set('step', String(step));
+
+  const res = await fetch(u.toString(), { signal, headers: { accept: 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`Prometheus query_range failed (${res.status})`);
+  }
+  const json = (await res.json()) as PromQueryRangeResponse;
+  if (json.status !== 'success' || !json.data) {
+    throw new Error(json.error || 'Prometheus error');
+  }
+
+  const series: MetricsSeries[] = json.data.result.map((r) => {
+    const labels = sanitizeLabels(r.metric || {});
+    return {
+      labels,
+      seriesName: labelsToSeriesName(labels),
+      points: (r.values || []).map(([ts, v]) => ({
+        ts: toUnixSeconds(ts),
+        value: parseFloatSafe(v),
+      })),
+    };
+  });
+
+  return {
+    source,
+    start,
+    end,
+    step,
+    series,
+    generatedAt: new Date().toISOString(),
+  };
+}
+

--- a/lib/metrics/sanitize.ts
+++ b/lib/metrics/sanitize.ts
@@ -1,0 +1,67 @@
+const SENSITIVE_LABEL_KEYS = new Set([
+  // Common PII keys
+  'email',
+  'phone',
+  'ssn',
+  'password',
+  'token',
+  'secret',
+  'authorization',
+  'cookie',
+  'userid',
+  'user_id',
+  'username',
+  'name',
+  'firstname',
+  'lastname',
+  // Infra keys that often embed IPs/hostnames (treated as sensitive for this UI)
+  'ip',
+  'ipaddress',
+  'instance',
+  'host',
+  'hostname',
+  'node',
+  'pod',
+  'container',
+  // Wallet / keys
+  'wallet',
+  'address',
+  'publickey',
+  'privatekey',
+  'account',
+  'sourceaccount',
+  'source_account',
+]);
+
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi;
+const LONG_BASE64_RE = /\b[A-Za-z0-9+/]{40,}={0,2}\b/g;
+const IPV4_RE = /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\b/g;
+// Stellar public keys are typically G + 55 chars of base32 (A-Z2-7)
+const STELLAR_G_ADDRESS_RE = /\bG[A-Z2-7]{55}\b/g;
+
+function scrubString(s: string): string {
+  return s
+    .replace(EMAIL_RE, '[redacted]')
+    .replace(IPV4_RE, '[redacted]')
+    .replace(STELLAR_G_ADDRESS_RE, '[redacted]')
+    .replace(LONG_BASE64_RE, '[redacted]');
+}
+
+export function sanitizeLabels(labels: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(labels)) {
+    const key = k.toLowerCase();
+    if (SENSITIVE_LABEL_KEYS.has(key)) continue;
+    out[k] = scrubString(v);
+  }
+  return out;
+}
+
+export function labelsToSeriesName(labels: Record<string, string>): string {
+  const entries = Object.entries(labels)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .slice(0, 6);
+  if (entries.length === 0) return 'total';
+  return entries.map(([k, v]) => `${k}=${v}`).join(', ');
+}
+

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -1,0 +1,40 @@
+export type MetricsRange = '15m' | '1h' | '6h' | '24h' | '7d';
+
+export type MetricsSource = 'prometheus' | 'otel_prometheus' | 'mock';
+
+export interface MetricsPanelDefinition {
+  id: string;
+  title: string;
+  description?: string;
+  group: 'system' | 'business';
+  unit?: 'ms' | 's' | 'percent' | 'bytes' | 'count' | 'rate_per_s' | 'xlm';
+  promqlRange: string;
+  promqlInstant?: string;
+}
+
+export interface MetricsSeriesPoint {
+  ts: number; // unix seconds
+  value: number;
+}
+
+export interface MetricsSeries {
+  seriesName: string;
+  labels: Record<string, string>;
+  points: MetricsSeriesPoint[];
+}
+
+export interface MetricsPanelResponse {
+  panelId: string;
+  source: MetricsSource;
+  start: number;
+  end: number;
+  step: number;
+  series: MetricsSeries[];
+  generatedAt: string;
+}
+
+export interface MetricsPanelsResponse {
+  source: MetricsSource;
+  panels: MetricsPanelDefinition[];
+}
+

--- a/tests/__tests__/analytics.test.tsx
+++ b/tests/__tests__/analytics.test.tsx
@@ -47,6 +47,18 @@ describe("Analytics Dashboard", () => {
 
   const mockFetch = jest.fn();
   global.fetch = mockFetch;
+  if (!URL.createObjectURL) {
+    // @ts-expect-error - jsdom may not implement this
+    URL.createObjectURL = () => "blob:mock";
+  }
+  if (!URL.revokeObjectURL) {
+    // @ts-expect-error - jsdom may not implement this
+    URL.revokeObjectURL = () => {};
+  }
+
+  const anchorClickSpy = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  const createObjectUrlSpy = jest.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+  const revokeObjectUrlSpy = jest.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
 
   beforeEach(() => {
     mockFetch.mockResolvedValue({
@@ -73,6 +85,12 @@ describe("Analytics Dashboard", () => {
         ],
       }),
     });
+  });
+
+  afterAll(() => {
+    anchorClickSpy.mockRestore();
+    createObjectUrlSpy.mockRestore();
+    revokeObjectUrlSpy.mockRestore();
   });
 
   afterEach(() => {

--- a/tests/__tests__/metrics-sanitize.test.ts
+++ b/tests/__tests__/metrics-sanitize.test.ts
@@ -1,0 +1,26 @@
+import { sanitizeLabels } from '@/lib/metrics/sanitize';
+
+describe('metrics sanitize', () => {
+  it('drops sensitive label keys', () => {
+    expect(
+      sanitizeLabels({
+        job: 'api',
+        email: 'x@y.com',
+        user_id: '123',
+        instance: '10.0.0.1:8080',
+      })
+    ).toEqual({ job: 'api' });
+  });
+
+  it('redacts sensitive values even on non-sensitive keys', () => {
+    const out = sanitizeLabels({
+      route: '/users/alice@example.com/profile',
+      peer: '10.12.1.9',
+      walletRef: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    });
+    expect(out.route).toContain('[redacted]');
+    expect(out.peer).toBe('[redacted]');
+    expect(out.walletRef).toBe('[redacted]');
+  });
+});
+


### PR DESCRIPTION
Adds system + business panels with filtering and CSV export, backed by safe predefined PromQL via API routes and PII-safe label sanitization.

closes #29 